### PR TITLE
Update link ads to now require page_id

### DIFF
--- a/lib/facebook_ads/ad_account.rb
+++ b/lib/facebook_ads/ad_account.rb
@@ -210,7 +210,7 @@ module FacebookAds
     end
 
     def create_link_ad_creative(creative)
-      required = %i[name title body object_url link_url image_hash]
+      required = %i[name title body object_url link_url image_hash page_id]
 
       unless (keys = required - creative.keys).length.zero?
         raise Exception, "Creative is missing the following: #{keys.join(', ')}"

--- a/lib/facebook_ads/ad_creative.rb
+++ b/lib/facebook_ads/ad_creative.rb
@@ -91,14 +91,20 @@ module FacebookAds
         }
       end
 
-      def link(name:, title:, body:, object_url:, link_url:, image_hash:)
+      def link(name:, title:, body:, object_url:, link_url:, image_hash:, page_id:)
+        object_story_spec = {
+          'page_id' => page_id,
+          'link_data' => {
+            'name' => title,
+            'message' => body,
+            'link' => link_url,
+            'image_hash' => image_hash,
+          }
+        }
+
         {
           name: name,
-          title: title,
-          body: body,
-          object_url: object_url,
-          link_url: link_url,
-          image_hash: image_hash
+          object_story_spec: object_story_spec.to_json
         }
       end
     end


### PR DESCRIPTION
Facebook recently started requiring pages to be linked to link ad creatives. The ad creative query structure has also changed and been updated to the latest docs.

https://developers.facebook.com/docs/marketing-api/reference/ad-creative/v2.11

https://newsroom.fb.com/news/2017/10/improving-enforcement-and-transparency/